### PR TITLE
ci: update workflows for develop/main branching strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - develop
+      - main
   pull_request:
 
 env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,9 +13,13 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "develop", "main" ]
+    branches:
+      - develop
+      - main
   pull_request:
-    branches: [ "develop", "main" ]
+    branches:
+      - develop
+      - main
   schedule:
     - cron: '34 4 * * 6'
 

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -2,7 +2,9 @@ name: Semgrep
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - develop
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
Update CI workflows to support simplified two-branch strategy:
- develop: primary development branch
- main: production releases

All PRs will trigger CI checks.

yu-fukunaga/tickets#15